### PR TITLE
Merging development state for third post

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,64 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bitflags"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "cc"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "ibish"
 version = "0.1.0"
 
 [[package]]
 name = "init"
 version = "0.1.0"
+dependencies = [
+ "nix",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,29 @@ KERNEL_DIRECTORY=linux-$(KERNEL_VERSION)
 KERNEL_ARCHIVE=$(KERNEL_DIRECTORY).tar.xz
 KERNEL_URL=https://cdn.kernel.org/pub/linux/kernel/v$(KERNEL_MAJOR_VERSION).x/$(KERNEL_ARCHIVE)
 
+RUST_USE_DEFAULT_FEATURES=true
+
+# Add features to enable for each program (using cargo feature syntax)
+RUST_FEATURES=
+RUST_FEATURES+= init/verbose_debug
+
+CARGO_FLAGS=--all --target=$(TARGET)
+
+# Turn off default package features
+ifeq ($(RUST_USE_DEFAULT_FEATURES), false)
+	CARGO_FLAGS+= --no-default-features
+endif
+
+ifneq ($(RUST_FEATURES),)
+	CARGO_FLAGS+= --features "$(RUST_FEATURES)"
+endif
+
 .PHONY: all
 all: vmlinuz initramfs
 
 .PHONY: rust_build
 rust_build: 
-	cargo build --all --target=$(TARGET)
+	cargo build $(CARGO_FLAGS)
 
 # Clean only the rust dependencies
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,24 @@ KERNEL_DIRECTORY=linux-$(KERNEL_VERSION)
 KERNEL_ARCHIVE=$(KERNEL_DIRECTORY).tar.xz
 KERNEL_URL=https://cdn.kernel.org/pub/linux/kernel/v$(KERNEL_MAJOR_VERSION).x/$(KERNEL_ARCHIVE)
 
+# Should we use the default features for the binaries
 RUST_USE_DEFAULT_FEATURES=true
+
+# Should we build in debug or release mode
+RUST_DEBUG_BUILD=true
 
 # Add features to enable for each program (using cargo feature syntax)
 RUST_FEATURES=
-RUST_FEATURES+= init/verbose_debug
 
 CARGO_FLAGS=--all --target=$(TARGET)
 
 # Turn off default package features
 ifeq ($(RUST_USE_DEFAULT_FEATURES), false)
 	CARGO_FLAGS+= --no-default-features
+endif
+
+ifneq ($(RUST_DEBUG_BUILD), true)
+	CARGO_FLAGS+= --release
 endif
 
 ifneq ($(RUST_FEATURES),)

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -5,4 +5,10 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["verbose_debug"]
+verbose_debug = []
+customizable_logo = []
+
 [dependencies]
+nix = "0.21"

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [features]
 default = []
-verbose_debug = []
 customizable_logo = []
 
 [dependencies]

--- a/src/init/Cargo.toml
+++ b/src/init/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["verbose_debug"]
+default = []
 verbose_debug = []
 customizable_logo = []
 

--- a/src/init/src/boot.rs
+++ b/src/init/src/boot.rs
@@ -1,0 +1,36 @@
+use crate::defaults;
+
+// Supress unused include warnings when the feature is disabled
+#[cfg(feature = "customizable_logo")]
+use std::{borrow::Cow, fs::File, io::Read};
+
+/// Try to load the logo provided by a user from `/logo.txt`
+///
+/// If this file cannot be found or read, this will provide a default logo
+/// from `defaults::DEFAULT_BANNER_LOGO`.
+#[cfg(feature = "customizable_logo")]
+pub fn get_boot_banner_logo() -> Cow<'static, str> {
+    match File::open("/logo.txt") {
+        Ok(mut logo_file) => {
+            let mut buffer = String::new();
+            if let Ok(_) = logo_file.read_to_string(&mut buffer) {
+                Cow::Owned(buffer)
+            } else {
+                Cow::Borrowed(defaults::DEFAULT_BANNER_LOGO)
+            }
+        }
+        Err(_) => Cow::Borrowed(defaults::DEFAULT_BANNER_LOGO),
+    }
+}
+
+/// Load the default Ibis logo
+#[cfg(not(feature = "customizable_logo"))]
+pub fn get_boot_banner_logo() -> &'static str {
+    defaults::DEFAULT_BANNER_LOGO
+}
+
+/// Print out useful information during boot including a nice logo
+pub fn print_boot_banner_info() {
+    let logo = get_boot_banner_logo();
+    println!("{}", logo);
+}

--- a/src/init/src/debug.rs
+++ b/src/init/src/debug.rs
@@ -1,0 +1,9 @@
+/// Fall into an unrecoverable state and display a helpful message
+///
+/// This function should be called with a helpful message when the `init`
+/// program cannot recover from an error it has encountered.
+/// This will spin forever right now.
+pub fn unrecoverable_error<M: std::fmt::Display>(msg: M) {
+    println!("init has encountered a serious error:\n\t{}\n\nPlease report a bug and reboot your system.", msg);
+    loop {}
+}

--- a/src/init/src/defaults.rs
+++ b/src/init/src/defaults.rs
@@ -1,0 +1,10 @@
+/// The default Ibis logo to be printed at the boot banner
+pub const DEFAULT_BANNER_LOGO: &'static str = r#" _____ _     _     
+|_   _| |   (_)    
+  | | | |__  _ ___ 
+  | | | '_ \| / __|
+ _| |_| |_) | \__ \
+ \___/|_.__/|_|___/"#;
+
+/// Set the defaults for the PATH variable we want to set up
+pub const DEFAULT_PATH: &'static str = "/sbin;/bin";

--- a/src/init/src/main.rs
+++ b/src/init/src/main.rs
@@ -2,8 +2,6 @@
 #[cfg(feature = "customizable_logo")]
 use std::{borrow::Cow, fs::File, io::Read};
 
-use nix::sys::signal::{sigprocmask, SigSet, SigmaskHow};
-
 /// The default Ibis logo
 const DEFAULT_BANNER_LOGO: &'static str = r#" _____ _     _     
 |_   _| |   (_)    
@@ -85,18 +83,6 @@ fn main() {
         println!("This process must be run as PID 1 (init)");
         // Exit with an error
         std::process::exit(1);
-    }
-
-    // Before we get too far, we should disable signals and other items like
-    // Ctrl-Alt-Delete to reboot. Later we can reenable things we want to handle
-    // as we get that set up properly.
-    if let Err(_error) = nix::sys::reboot::set_cad_enabled(false) {
-        unrecoverable_error("Could not disable Ctrl-Alt-Delete");
-    }
-
-    let signal_set = SigSet::all();
-    if let Err(_error) = sigprocmask(SigmaskHow::SIG_SETMASK, Some(&signal_set), None) {
-        unrecoverable_error("Could not disable signals");
     }
 
     print_boot_banner_info();

--- a/src/init/src/main.rs
+++ b/src/init/src/main.rs
@@ -1,23 +1,108 @@
+use std::borrow::Cow;
+#[cfg(feature = "customizable_logo")]
 use std::{fs::File, io::Read};
 
-fn main() {
-    // We need a PATH or `ibish` won't work :(
-    std::env::set_var("PATH", "/");
+use nix::sys::signal::{sigprocmask, SigSet, SigmaskHow};
 
+const DEFAULT_BANNER_LOGO: &'static str = r#" _____ _     _     
+|_   _| |   (_)    
+  | | | |__  _ ___ 
+  | | | '_ \| / __|
+ _| |_| |_) | \__ \
+ \___/|_.__/|_|___/"#;
+
+const DEFAULT_PATH: &'static str = "/sbin;/bin";
+
+fn unrecoverable_error<M: std::fmt::Display>(msg: M) {
+    println!("init has encountered a serious error:\n\t{}\n\nPlease report a bug and reboot your system.", msg);
+    #[cfg(feature = "verbose_debug")]
+    debug_dump_env();
+    loop {}
+}
+
+/// Try to load the logo provided by a user from `/logo.txt`
+///
+/// If this file cannot be found or read, this will provide a default logo
+/// from `DEFAULT_BANNER_LOGO`.
+#[cfg(feature = "customizable_logo")]
+fn get_boot_banner_logo() -> Cow<'static, str> {
+    match File::open("/logo.txt") {
+        Ok(mut logo_file) => {
+            let mut buffer = String::new();
+            if let Ok(_) = logo_file.read_to_string(&mut buffer) {
+                Cow::Owned(buffer)
+            } else {
+                Cow::Borrowed(DEFAULT_BANNER_LOGO)
+            }
+        }
+        Err(_) => Cow::Borrowed(DEFAULT_BANNER_LOGO),
+    }
+}
+
+#[cfg(not(feature = "customizable_logo"))]
+fn get_boot_banner_logo() -> Cow<'static, str> {
+    Cow::Borrowed(DEFAULT_BANNER_LOGO)
+}
+
+#[cfg(feature = "verbose_debug")]
+fn debug_dump_env() {
     for (var, value) in std::env::vars() {
         println!("{}: {}", var, value);
     }
+}
 
-    let mut logo_file = File::open("/logo.txt").unwrap();
-    let mut buffer = String::new();
+fn on_shutdown_request() {
+    println!("Terminating all processes");
+    // Setting PID to -1 indicates we want to kill every process we have
+    // permission to do so (man 3 kill). In this case it should be everything
+    // because we are `init`
+    if let Err(_error) = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(-1),
+        nix::sys::signal::Signal::SIGTERM,
+    ) {
+        println!("Failure trying to kill processes during shutdown");
+    }
 
-    logo_file.read_to_string(&mut buffer).unwrap();
+    // Per the documentaiton (`man 3 reboot`) we must issue a `sync` prior
+    // to using `RB_POWER_OFF` or else we could lose data.
+    // This would make our users very unhappy
+    nix::unistd::sync();
+    if let Err(_error) = nix::sys::reboot::reboot(nix::sys::reboot::RebootMode::RB_POWER_OFF) {
+        unrecoverable_error("Could not initiate shutdown");
+    }
+}
 
-    println!("Hello, Ibis!\n{}", buffer);
+fn main() {
+    // Let's make sure we are PID 1, we're not designed to do anything else.
+    if std::process::id() != 1 {
+        println!("This process must be run as PID 1 (init)");
+        std::process::exit(1);
+    }
+
+    // Before we get too far, we should disable signals and other items like
+    // Ctrl-Alt-Delete to reboot. Later we can reenable things we want to handle
+    // as we get that set up properly.
+    if let Err(_error) = nix::sys::reboot::set_cad_enabled(false) {
+        unrecoverable_error("Could not disable Ctrl-Alt-Delete");
+    }
+
+    let signal_set = SigSet::all();
+    if let Err(_error) = sigprocmask(SigmaskHow::SIG_SETMASK, Some(&signal_set), None) {
+        unrecoverable_error("Could not disable signals");
+    }
+
+    // Get and print a logo indicating that we are booting
+    let logo = get_boot_banner_logo();
+    println!("{}", logo);
+    println!("\tv{}", env!("CARGO_PKG_VERSION"));
+
+    // We need a PATH or `ibish` won't work :(
+    std::env::set_var("PATH", DEFAULT_PATH);
 
     loop {
         // Infinitely respawn shells
         let mut child = std::process::Command::new("/ibish").spawn().unwrap();
         child.wait().unwrap();
+        on_shutdown_request();
     }
 }

--- a/src/init/src/main.rs
+++ b/src/init/src/main.rs
@@ -1,9 +1,10 @@
-use std::borrow::Cow;
+// Supress unused include warnings when the feature is disabled
 #[cfg(feature = "customizable_logo")]
-use std::{fs::File, io::Read};
+use std::{borrow::Cow, fs::File, io::Read};
 
 use nix::sys::signal::{sigprocmask, SigSet, SigmaskHow};
 
+/// The default Ibis logo
 const DEFAULT_BANNER_LOGO: &'static str = r#" _____ _     _     
 |_   _| |   (_)    
   | | | |__  _ ___ 
@@ -39,9 +40,10 @@ fn get_boot_banner_logo() -> Cow<'static, str> {
     }
 }
 
+/// Load the default Ibis logo
 #[cfg(not(feature = "customizable_logo"))]
-fn get_boot_banner_logo() -> Cow<'static, str> {
-    Cow::Borrowed(DEFAULT_BANNER_LOGO)
+fn get_boot_banner_logo() -> &'static str {
+    DEFAULT_BANNER_LOGO
 }
 
 #[cfg(feature = "verbose_debug")]
@@ -72,10 +74,16 @@ fn on_shutdown_request() {
     }
 }
 
+fn print_boot_banner_info() {
+    let logo = get_boot_banner_logo();
+    println!("{}", logo);
+}
+
 fn main() {
     // Let's make sure we are PID 1, we're not designed to do anything else.
     if std::process::id() != 1 {
         println!("This process must be run as PID 1 (init)");
+        // Exit with an error
         std::process::exit(1);
     }
 
@@ -91,10 +99,7 @@ fn main() {
         unrecoverable_error("Could not disable signals");
     }
 
-    // Get and print a logo indicating that we are booting
-    let logo = get_boot_banner_logo();
-    println!("{}", logo);
-    println!("\tv{}", env!("CARGO_PKG_VERSION"));
+    print_boot_banner_info();
 
     // We need a PATH or `ibish` won't work :(
     std::env::set_var("PATH", DEFAULT_PATH);

--- a/src/init/src/shutdown.rs
+++ b/src/init/src/shutdown.rs
@@ -1,0 +1,28 @@
+use crate::debug::unrecoverable_error;
+
+/// Perform a graceful shutdown of the system
+///
+/// There are several stages here:
+///  1. Terminate all processes in the system
+///  2. Sync the filesystem
+///  3. Inform the kernel to shutdown and power-off
+pub fn on_shutdown_request() {
+    println!("Terminating all processes");
+    // Setting PID to -1 indicates we want to kill every process we have
+    // permission to do so (man 3 kill). In this case it should be everything
+    // because we are `init`
+    if let Err(_error) = nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(-1),
+        nix::sys::signal::Signal::SIGTERM,
+    ) {
+        println!("Failure trying to kill processes during shutdown");
+    }
+
+    // Per the documentaiton (`man 3 reboot`) we must issue a `sync` prior
+    // to using `RB_POWER_OFF` or else we could lose data.
+    // This would make our users very unhappy
+    nix::unistd::sync();
+    if let Err(_error) = nix::sys::reboot::reboot(nix::sys::reboot::RebootMode::RB_POWER_OFF) {
+        unrecoverable_error("Could not initiate shutdown");
+    }
+}

--- a/src/init/src/shutdown.rs
+++ b/src/init/src/shutdown.rs
@@ -9,7 +9,7 @@ use crate::debug::unrecoverable_error;
 pub fn on_shutdown_request() {
     println!("Terminating all processes");
     // Setting PID to -1 indicates we want to kill every process we have
-    // permission to do so (man 3 kill). In this case it should be everything
+    // permission to do so (man 2 kill). In this case it should be everything
     // because we are `init`
     if let Err(_error) = nix::sys::signal::kill(
         nix::unistd::Pid::from_raw(-1),
@@ -18,7 +18,7 @@ pub fn on_shutdown_request() {
         println!("Failure trying to kill processes during shutdown");
     }
 
-    // Per the documentaiton (`man 3 reboot`) we must issue a `sync` prior
+    // Per the documentaiton (`man 2 reboot`) we must issue a `sync` prior
     // to using `RB_POWER_OFF` or else we could lose data.
     // This would make our users very unhappy
     nix::unistd::sync();


### PR DESCRIPTION
This cleans up the `init` program and adds some error handling. 
A new Cargo feature is enabled which allows turning back on custom boot banner logos, and a corresponding Makefile change allows make to pipe cargo features from the Makefile to cargo properly. 

These changes accompany the third post in the series. 